### PR TITLE
Update driver to use embedded_hal v2 traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
 name = "tm1637"
-version = "0.0.1"
-authors = ["Sergey Vakhurin <igelbox@gmail.com>"]
+version = "0.1.0"
+authors = [
+    "Sergey Vakhurin <igelbox@gmail.com>",
+    "Jesse Braham <jesse@beta7.io>",
+]
 description = "A platform agnostic driver to a LED-display powered by the TM1637 chip"
 keywords = ["embedded", "embedded-hal-driver"]
 categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT"
 repository = "https://github.com/igelbox/tm1637-rs"
+edition = "2018"
 
-[dependencies.embedded-hal]
-features = ["unproven"]
-version = "0.2.2"
+[dependencies]
+embedded-hal = { version = "0.2.3", features = ["unproven"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tm1637"
-version = "0.1.0"
+version = "0.0.1"
 authors = [
     "Sergey Vakhurin <igelbox@gmail.com>",
     "Jesse Braham <jesse@beta7.io>",
@@ -12,5 +12,6 @@ license = "MIT"
 repository = "https://github.com/igelbox/tm1637-rs"
 edition = "2018"
 
-[dependencies]
-embedded-hal = { version = "0.2.3", features = ["unproven"]}
+[dependencies.embedded-hal]
+features = ["unproven"]
+version = "0.2.3"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `TM1639`
+# `TM1637`
 > A platform agnostic driver to a LED-display powered by the TM1637 chip
 
 ## What works

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,31 @@
 extern crate embedded_hal as hal;
 
 use hal::blocking::delay::DelayUs;
-use hal::digital::{InputPin, OutputPin};
+use hal::digital::v2::{InputPin, OutputPin};
+
+const MAX_FREQ_KHZ: u16 = 500;
+const USECS_IN_MSEC: u16 = 1_000;
+const DELAY_USECS: u16 = USECS_IN_MSEC / MAX_FREQ_KHZ;
+
+const ADDRESS_AUTO_INCREMENT_1_MODE: u8 = 0x40;
+
+const ADDRESS_COMMAND_BITS: u8 = 0xc0;
+const ADDRESS_COMMAND_MASK: u8 = 0x0f;
+
+const DISPLAY_CONTROL_BRIGHTNESS_BITS: u8 = 0x88;
+const DISPLAY_CONTROL_BRIGHTNESS_MASK: u8 = 0x07;
+
+const DIGITS: [u8; 16] = [
+    0x3f, 0x06, 0x5b, 0x4f, //
+    0x66, 0x6d, 0x7d, 0x07, //
+    0x7f, 0x6f, 0x77, 0x7c, //
+    0x39, 0x5e, 0x79, 0x71, //
+];
 
 #[derive(Debug)]
 pub enum Error {
     Ack,
+    IO,
 }
 
 pub struct TM1637<'a, CLK, DIO, D> {
@@ -17,10 +37,10 @@ pub struct TM1637<'a, CLK, DIO, D> {
     delay: &'a mut D,
 }
 
-impl<'a, CLK, DIO, D> TM1637<'a, CLK, DIO, D>
+impl<'a, E, CLK, DIO, D> TM1637<'a, CLK, DIO, D>
 where
-    CLK: OutputPin,
-    DIO: InputPin + OutputPin,
+    CLK: OutputPin<Error = E>,
+    DIO: InputPin<Error = E> + OutputPin<Error = E>,
     D: DelayUs<u16>,
 {
     pub fn new(clk: &'a mut CLK, dio: &'a mut DIO, delay: &'a mut D) -> Self {
@@ -28,9 +48,10 @@ where
     }
 
     pub fn init(&mut self) -> Result<(), Error> {
-        self.start();
+        self.start()?;
         self.send(ADDRESS_AUTO_INCREMENT_1_MODE)?;
-        self.stop();
+        self.stop()?;
+
         Ok(())
     }
 
@@ -54,42 +75,43 @@ where
         address: u8,
         bytes: Iter,
     ) -> Result<(), Error> {
-        self.start();
+        self.start()?;
         self.send(ADDRESS_COMMAND_BITS | (address & ADDRESS_COMMAND_MASK))?;
         for byte in bytes {
             self.send(byte)?;
         }
-        self.stop();
+        self.stop()?;
         Ok(())
     }
 
     pub fn set_brightness(&mut self, level: u8) -> Result<(), Error> {
-        self.start();
+        self.start()?;
         self.send(DISPLAY_CONTROL_BRIGHTNESS_BITS | (level & DISPLAY_CONTROL_BRIGHTNESS_MASK))?;
-        self.stop();
+        self.stop()?;
+
         Ok(())
     }
 
     fn send(&mut self, byte: u8) -> Result<(), Error> {
         let mut rest = byte;
         for _ in 0..8 {
-            self.clk.set_low();
+            self.clk.set_low().map_err(|_| Error::IO).unwrap();
             if rest & 1 != 0 {
-                self.dio.set_high()
+                self.dio.set_high().map_err(|_| Error::IO).unwrap();
             } else {
-                self.dio.set_low()
+                self.dio.set_low().map_err(|_| Error::IO).unwrap();
             }
             rest = rest >> 1;
-            self.clk.set_high();
+            self.clk.set_high().map_err(|_| Error::IO).unwrap();
             self.delay();
         }
 
         // Wait for the ACK
-        self.clk.set_low();
-        self.dio.set_high();
-        self.clk.set_high();
+        self.clk.set_low().map_err(|_| Error::IO).unwrap();
+        self.dio.set_high().map_err(|_| Error::IO).unwrap();
+        self.clk.set_high().map_err(|_| Error::IO).unwrap();
         for _ in 0..255 {
-            if !self.dio.is_high() {
+            if self.dio.is_low().map_err(|_| Error::IO).unwrap() {
                 return Ok(());
             }
             self.delay();
@@ -98,43 +120,28 @@ where
         Err(Error::Ack)
     }
 
-    fn start(&mut self) {
-        self.clk.set_low();
-        self.dio.set_high();
-        self.clk.set_high();
+    fn start(&mut self) -> Result<(), Error> {
+        self.clk.set_low().map_err(|_| Error::IO).unwrap();
+        self.dio.set_high().map_err(|_| Error::IO).unwrap();
+        self.clk.set_high().map_err(|_| Error::IO).unwrap();
         self.delay();
-        self.dio.set_low();
+        self.dio.set_low().map_err(|_| Error::IO).unwrap();
+
+        Ok(())
     }
 
-    fn stop(&mut self) {
-        self.clk.set_low();
-        self.dio.set_low();
-        self.clk.set_high();
+    fn stop(&mut self) -> Result<(), Error> {
+        self.clk.set_low().map_err(|_| Error::IO).unwrap();
+        self.dio.set_low().map_err(|_| Error::IO).unwrap();
+        self.clk.set_high().map_err(|_| Error::IO).unwrap();
         self.delay();
-        self.dio.set_high();
+        self.dio.set_high().map_err(|_| Error::IO).unwrap();
         self.delay();
+
+        Ok(())
     }
 
     fn delay(&mut self) {
         self.delay.delay_us(DELAY_USECS);
     }
 }
-
-const MAX_FREQ_KHZ: u16 = 250;
-const USECS_IN_MSEC: u16 = 1_000;
-const DELAY_USECS: u16 = USECS_IN_MSEC / MAX_FREQ_KHZ;
-
-const ADDRESS_AUTO_INCREMENT_1_MODE: u8 = 0x40;
-
-const ADDRESS_COMMAND_BITS: u8 = 0xc0;
-const ADDRESS_COMMAND_MASK: u8 = 0x0f;
-
-const DISPLAY_CONTROL_BRIGHTNESS_BITS: u8 = 0x88;
-const DISPLAY_CONTROL_BRIGHTNESS_MASK: u8 = 0x07;
-
-const DIGITS: [u8; 16] = [
-    0x3f, 0x06, 0x5b, 0x4f, //
-    0x66, 0x6d, 0x7d, 0x07, //
-    0x7f, 0x6f, 0x77, 0x7c, //
-    0x39, 0x5e, 0x79, 0x71, //
-];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,25 +6,6 @@ extern crate embedded_hal as hal;
 use hal::blocking::delay::DelayUs;
 use hal::digital::v2::{InputPin, OutputPin};
 
-const MAX_FREQ_KHZ: u16 = 500;
-const USECS_IN_MSEC: u16 = 1_000;
-const DELAY_USECS: u16 = USECS_IN_MSEC / MAX_FREQ_KHZ;
-
-const ADDRESS_AUTO_INCREMENT_1_MODE: u8 = 0x40;
-
-const ADDRESS_COMMAND_BITS: u8 = 0xc0;
-const ADDRESS_COMMAND_MASK: u8 = 0x0f;
-
-const DISPLAY_CONTROL_BRIGHTNESS_BITS: u8 = 0x88;
-const DISPLAY_CONTROL_BRIGHTNESS_MASK: u8 = 0x07;
-
-const DIGITS: [u8; 16] = [
-    0x3f, 0x06, 0x5b, 0x4f, //
-    0x66, 0x6d, 0x7d, 0x07, //
-    0x7f, 0x6f, 0x77, 0x7c, //
-    0x39, 0x5e, 0x79, 0x71, //
-];
-
 #[derive(Debug)]
 pub enum Error {
     Ack,
@@ -145,3 +126,22 @@ where
         self.delay.delay_us(DELAY_USECS);
     }
 }
+
+const MAX_FREQ_KHZ: u16 = 500;
+const USECS_IN_MSEC: u16 = 1_000;
+const DELAY_USECS: u16 = USECS_IN_MSEC / MAX_FREQ_KHZ;
+
+const ADDRESS_AUTO_INCREMENT_1_MODE: u8 = 0x40;
+
+const ADDRESS_COMMAND_BITS: u8 = 0xc0;
+const ADDRESS_COMMAND_MASK: u8 = 0x0f;
+
+const DISPLAY_CONTROL_BRIGHTNESS_BITS: u8 = 0x88;
+const DISPLAY_CONTROL_BRIGHTNESS_MASK: u8 = 0x07;
+
+const DIGITS: [u8; 16] = [
+    0x3f, 0x06, 0x5b, 0x4f, //
+    0x66, 0x6d, 0x7d, 0x07, //
+    0x7f, 0x6f, 0x77, 0x7c, //
+    0x39, 0x5e, 0x79, 0x71, //
+];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub struct TM1637<'a, CLK, DIO, D> {
     delay: &'a mut D,
 }
 
-impl<'a, E, CLK, DIO, D> TM1637<'a, CLK, DIO, D>
+impl<'a, CLK, DIO, D, E> TM1637<'a, CLK, DIO, D>
 where
     CLK: OutputPin<Error = E>,
     DIO: InputPin<Error = E> + OutputPin<Error = E>,


### PR DESCRIPTION
As stated in the title, I have updated this library to used the `embedded_hal::digital::v2` traits. This primarily consisted of updating the error handling. I have tested this and confirmed it is working.

I have also bumped the version number so it should be ready for a release as is.