### PR TITLE
lib: replace held reference to Delay with function params

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -38,17 +38,17 @@ fn main() -> ! {
     let mut delay = Delay::new(cp.SYST, clocks);
 
     let mut delay = NoDelay {}; // remove this line to use the real HW delay
-    let mut tm = TM1637::new(&mut clk, &mut dio, &mut delay);
-    tm.init(); // append `.unwrap()` to catch and handle exceptions in cost of extra ROM size
-    tm.clear();
+    let mut tm = TM1637::new(&mut clk, &mut dio);
+    tm.init(&mut delay); // append `.unwrap()` to catch and handle exceptions in cost of extra ROM size
+    tm.clear(&mut delay);
 
     loop {
         for i in 0..255 {
-            tm.print_hex(0, &[i, i + 1]);
+            tm.print_hex(0, &[i, i + 1], &mut delay);
 
-            tm.print_raw(3, &[i]);
+            tm.print_raw(3, &[i], &mut delay);
 
-            tm.set_brightness(i >> 5);
+            tm.set_brightness(i >> 5, &mut delay);
         }
     }
 }


### PR DESCRIPTION
Hi, thanks for writing this driver!

I have the need for driving multiple 7-segment displays with the tm1637 chip and I found that multiple instances proved difficult due to the reference it holds on the Delay.

I was pointed towards [asm-delay](https://lib.rs/install/asm-delay) by a member of the rust-embedded matrix chat as a workaround but didn't manage to get it to work. So I modified the interface to take a reference to Delay in each function thar requires it.

I'm sure there will be a better method than having to repeat the type predicate on each function but I haven't found it yet.