### PR TITLE
Make sure clock pulses have a defined length

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,12 +125,12 @@ where
 
     fn send_bit_and_delay(&mut self, value: Bit) -> Res<E> {
         self.clk.set_low()?;
+        self.delay();
         if let Bit::ONE = value {
             self.dio.set_high()?;
         } else {
             self.dio.set_low()?;
         }
-        self.delay();
         self.clk.set_high()?;
         self.delay();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ where
                 return Ok(());
             }
             self.delay();
+            self.delay();
         }
 
         Err(Error::Ack)
@@ -117,6 +118,7 @@ where
         self.send_bit_and_delay(Bit::ZERO)?;
         self.dio.set_high()?;
         self.delay();
+        self.delay();
 
         Ok(())
     }
@@ -128,6 +130,7 @@ where
         } else {
             self.dio.set_low()?;
         }
+        self.delay();
         self.clk.set_high()?;
         self.delay();
 
@@ -141,7 +144,7 @@ where
 
 const MAX_FREQ_KHZ: u16 = 500;
 const USECS_IN_MSEC: u16 = 1_000;
-const DELAY_USECS: u16 = USECS_IN_MSEC / MAX_FREQ_KHZ;
+const DELAY_USECS: u16 = USECS_IN_MSEC.div_ceil(MAX_FREQ_KHZ * 2);
 
 const ADDRESS_AUTO_INCREMENT_1_MODE: u8 = 0x40;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,12 +125,12 @@ where
 
     fn send_bit_and_delay(&mut self, value: Bit) -> Res<E> {
         self.clk.set_low()?;
-        self.delay();
         if let Bit::ONE = value {
             self.dio.set_high()?;
         } else {
             self.dio.set_low()?;
         }
+        self.delay();
         self.clk.set_high()?;
         self.delay();
 


### PR DESCRIPTION
Currently, clock pulses can be arbitrarily short, as the whole clock delay is done after setting clk to low, setting the data bit, and setting clk to high again. On fast processors, the clk pulse can become too short to be recognized reliably, which may be the cause for issue #5.

To fix that, split the delay in two equal halves, and do one of them while the clock is low.

I duplicated all other calls to delay() to keep the delay lengths stable. This might not be necessary, but shouldn't hurt either.